### PR TITLE
Some fixes in sessions controller, Task model and tasks table

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -24,7 +24,14 @@ module Api
       end
 
       def current
-        @next_session = Task.where(done: false).first.sessions.where(completed: false).first
+        @next_session =
+          if Task.count.zero? && Session.count.zero?
+            Session.create
+          elsif Task.count.zero?
+            Session.first
+          else
+            Task.where(done: false).first.sessions.where(completed: false).first
+          end
         render json: @next_session
       end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
-  has_many :sessions, dependent: :destroy
+  has_many :sessions, dependent: :nullify
 
   validates :name, presence: true
   validates_inclusion_of :done, in: [true, false]

--- a/db/migrate/20211222200530_change_default_value_of_pomodoros_in_tasks.rb
+++ b/db/migrate/20211222200530_change_default_value_of_pomodoros_in_tasks.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultValueOfPomodorosInTasks < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :tasks, :pomodoros, from: 0, to: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_17_110126) do
+ActiveRecord::Schema.define(version: 2021_12_22_200530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2021_12_17_110126) do
     t.boolean "done", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "pomodoros", default: 0
+    t.integer "pomodoros", default: 1
     t.integer "completed", default: 0
   end
 


### PR DESCRIPTION
- Improve `current` action in `sessions controller`
- Allow destroying tasks but not sessions in the `Task` model
- Change default value of `pomodoros` in `tasks` table